### PR TITLE
fix Tools crash on iPads

### DIFF
--- a/Pogo/ViewController.swift
+++ b/Pogo/ViewController.swift
@@ -212,6 +212,11 @@ class ViewController: BaseViewController {
     // tools popup
     @objc private func showTools() {
         let alert = UIAlertController(title: "Tools", message: "Select", preferredStyle: .actionSheet)
+        
+        let popover = alert.popoverPresentationController
+        popover?.sourceView = view
+        popover?.sourceRect = CGRect(x: 0, y: 0, width: 64, height: 64)
+        
         alert.addAction(UIAlertAction(title: "uicache", style: .default, handler: { _ in
             self.runUiCache()
         }))

--- a/Pogo/ViewController.swift
+++ b/Pogo/ViewController.swift
@@ -212,7 +212,6 @@ class ViewController: BaseViewController {
     // tools popup
     @objc private func showTools() {
         let alert = UIAlertController(title: "Tools", message: "Select", preferredStyle: .actionSheet)
-        
         let popover = alert.popoverPresentationController
         popover?.sourceView = view
         popover?.sourceRect = CGRect(x: 0, y: 0, width: 64, height: 64)


### PR DESCRIPTION
On iPads sourceView and sourceRect is required for popups as it doesnt swipe up from the botton. (basically fix for #10)
This should not break the popup on iPhones but i couldn‘t verify because i dont own one.