### PR TITLE
wait for apps to be unregistered before removing strap

### DIFF
--- a/Pogo/ViewController.swift
+++ b/Pogo/ViewController.swift
@@ -175,14 +175,12 @@ class ViewController: BaseViewController {
                     }                
                 }
             }
-
-        }
-        statusLabel?.text = "Removing Strap"
-        DispatchQueue.global(qos: .utility).async { [self] in
+            self.statusLabel?.text = "Removing Strap"
             let ret = spawn(command: helper, args: ["-r"], root: true)
             DispatchQueue.main.async {
                 if ret != 0 {
                     self.statusLabel?.text = "Failed to remove :( \(ret)"
+                    return
                 }
                 self.statusLabel?.text = "omg its gone!"
             }


### PR DESCRIPTION
without this unregistering apps might fail if there are two or more apps in /var/jb/Applications, because Procursus is already removed.